### PR TITLE
Add File Extension Verification By MIME Type

### DIFF
--- a/AllowedUploadsPlugin.inc.php
+++ b/AllowedUploadsPlugin.inc.php
@@ -94,9 +94,12 @@ class AllowedUploadsPlugin extends GenericPlugin {
 				if ($request->getUserVar('save')) {
 					$form->readInputData();
 					if ($form->validate()) {
-						$form->execute();
-						return new JSONMessage(true);
+						$executeResult = $form->execute();
+						if ($executeResult !== false) {
+							return new JSONMessage(true);
+						}
 					}
+					return new JSONMessage(true, $form->fetch($request));
 				} else {
 					$form->initData();
 				}
@@ -253,6 +256,15 @@ class AllowedUploadsPlugin extends GenericPlugin {
 			];
 		}
 
+		// Check for empty files (if we have a file path and empty files are disallowed)
+		$allowEmptyFiles = $this->getSetting($contextId, 'allowEmptyFiles') ?? true;
+		if (!$allowEmptyFiles && $filePath && file_exists($filePath) && filesize($filePath) === 0) {
+			return [
+				'valid' => false,
+				'error' => __('plugins.generic.allowedUploads.error.emptyFile', ['fileName' => $fileName])
+			];
+		}
+
         // Check for multiple extensions
         if (count($parts) > 2) {
             // Check if a double extension is explicitly allowed
@@ -290,6 +302,11 @@ class AllowedUploadsPlugin extends GenericPlugin {
             error_log("AllowedUploads: Could not determine MIME type of file " . $fileName);
             return ['valid' => true, 'error' => null];
         }
+
+		// Allow empty MIME types to pass (handled separately above)
+		if ($detectedMimeType === 'application/x-empty' || $detectedMimeType === 'inode/x-empty') {
+			return ['valid' => true, 'error' => null];
+		}
 
         $expectedMimeTypes = $this->getExpectedMimeTypes($extension);
         if (!empty($expectedMimeTypes) && !in_array($detectedMimeType, $expectedMimeTypes)) {

--- a/AllowedUploadsPlugin.inc.php
+++ b/AllowedUploadsPlugin.inc.php
@@ -227,8 +227,8 @@ class AllowedUploadsPlugin extends GenericPlugin {
      * @return array Array with 'valid' boolean and 'error' message
      */
     private function validateFileType($fileName, $filePath, $allowedExtensions, $contextId) {
-        $parts = explode('.', $fileName);
-        $allowedExtensionsArray = array_filter(array_map('trim', explode(';', $allowedExtensions)), 'strlen');
+		$parts = explode('.', $fileName);
+		$allowedExtensionsArray = array_filter(array_map('trim', explode(';', $allowedExtensions)), 'strlen');
 
         // Check for multiple extensions
         if (count($parts) > 2) {
@@ -284,7 +284,11 @@ class AllowedUploadsPlugin extends GenericPlugin {
     }
 
 	/**
-	 * Check the uploaded file in wizard
+	 * Check the uploaded file in the submission wizard
+	 * Hook: SubmissionFile::validate
+	 * @param string $hookName Name of hook being called
+	 * @param array $params Hook parameters: errors array, submission, props, actions, locale
+	 * @return bool Always returns false to allow other hooks to process
 	 */
     function checkUploadWizard($hookName, $params) {
         $props = $params[2];
@@ -295,26 +299,31 @@ class AllowedUploadsPlugin extends GenericPlugin {
             $request = Application::get()->getRequest();
             $context = $request->getContext();
             $contextId = $context->getId();
-            
+
             $allowedExtensions = $this->getSetting($contextId, 'allowedExtensions');
 
             if ($allowedExtensions){
-                // Try to get the file path if available
-                $filePath = null;
-                if (isset($props['uploadedFile']) && $props['uploadedFile']) {
-                    $filePath = $props['uploadedFile']->getFilePath();
-                }
-                
+				// Get the uploaded file path from $_FILES
+				$filePath = null;
+				if (isset($_FILES['file']) && isset($_FILES['file']['tmp_name'])) {
+					$filePath = $_FILES['file']['tmp_name'];
+				}
+
                 $validation = $this->validateFileType($fileName, $filePath, $allowedExtensions, $contextId);
                 if (!$validation['valid']) {
                     $errors[] = $validation['error'];
                 }
             }
         }
+		return false;
     }
 
 	/**
-	 * Check the uploaded file
+	 * Check the uploaded file in the upload form
+	 * Hook: submissionfilesuploadform::validate
+	 * @param string $hookName Name of hook being called
+	 * @param array $params Hook parameters: form object
+	 * @return bool Always returns fale to allow other hooks to process
 	 */
     function checkUpload($hookName, $params) {
         $form = $params[0];
@@ -322,20 +331,19 @@ class AllowedUploadsPlugin extends GenericPlugin {
         $context = $request->getContext();
         $contextId = $context->getId();
         $userVars = $request->getUserVars();
-        $fileName = $userVars['name'];
+        $fileName = $userVars['name'] ?? null;
+		if (!$fileName) {
+			return false;
+		}
 
         $allowedExtensions = $this->getSetting($contextId, 'allowedExtensions');
 
         if ($allowedExtensions){
-            // Try to get the uploaded file path
-            $filePath = null;
-            $uploadedFiles = $request->getUploadedFiles();
-            if (!empty($uploadedFiles)) {
-                $uploadedFile = reset($uploadedFiles); // Get first uploaded file
-                if ($uploadedFile && is_array($uploadedFile)) {
-                    $filePath = $uploadedFile['tmp_name'] ?? null;
-                }
-            }
+			// Get the uploaded file path from $_FILES
+			$filePath = null;
+			if (isset($_FILES['file']) && isset($_FILES['file']['tmp_name'])) {
+				$filePath = $_FILES['file']['tmp_name'];
+			}
 
             $validation = $this->validateFileType($fileName, $filePath, $allowedExtensions, $contextId);
             if (!$validation['valid']) {
@@ -344,7 +352,6 @@ class AllowedUploadsPlugin extends GenericPlugin {
         }
         return false;
     }
-
 
 }
 ?>

--- a/AllowedUploadsPlugin.inc.php
+++ b/AllowedUploadsPlugin.inc.php
@@ -112,6 +112,7 @@ class AllowedUploadsPlugin extends GenericPlugin {
 	 */
     private function getMimeTypeFromFile($filePath) {
         if (!file_exists($filePath)) {
+			error_log("AllowedUploads: File not found for MIME detection: " . $filePath);
             return false;
         }
 
@@ -121,15 +122,25 @@ class AllowedUploadsPlugin extends GenericPlugin {
             if ($finfo) {
                 $mimeType = finfo_file($finfo, $filePath);
                 finfo_close($finfo);
-                return $mimeType;
-            }
-        }
+				if ($mimeType !== false) {
+                	return $mimeType;
+				}
+				error_log("AllowedUploads: finfo_file failed for: " . $filePath);
+        	} else {
+				error_log("AllowedUploads: finfo_open failed");
+			}
+		}
 
         // Fallback to mime_content_type as failsafe
         if (function_exists('mime_content_type')) {
-            return mime_content_type($filePath);
+			$mimeType = mime_content_type($filePath);
+            if ($mimeType !== false) {
+				return $mimeType;
+			}
+			error_log("AllowedUploads: mime_content_type failed for: " . $filePath);
         }
 
+		error_log("AllowedUploads: All MIME detection methods failed for: " . $filePath);
         return false;
     }
 
@@ -204,9 +215,9 @@ class AllowedUploadsPlugin extends GenericPlugin {
 			'r' => ['text/plain'],
 
 			// Statistical formats
-			'sav' => ['application/x-spss-sav'],
 			'dta' => ['application/x-stata-dta'],
 			'sas7bdat' => ['application/x-sas-data'],
+			'sav' => ['application/x-spss-sav'],
 
 			// Audio/Video
 			'avi' => ['video/x-msvideo'],
@@ -227,8 +238,20 @@ class AllowedUploadsPlugin extends GenericPlugin {
      * @return array Array with 'valid' boolean and 'error' message
      */
     private function validateFileType($fileName, $filePath, $allowedExtensions, $contextId) {
+		$request = Application::get()->getRequest();
+		$user = $request->getUser();
+		$userId = $user ? $user->getId() : 'anonymous';
+
 		$parts = explode('.', $fileName);
 		$allowedExtensionsArray = array_filter(array_map('trim', explode(';', $allowedExtensions)), 'strlen');
+
+		// Check for extensionless files
+		if (count($parts) < 2) {
+			return [
+				'valid' => false,
+				'error' => __('plugins.generic.allowedUploads.error.noExtension', ['fileName' => $fileName])
+			];
+		}
 
         // Check for multiple extensions
         if (count($parts) > 2) {
@@ -264,13 +287,15 @@ class AllowedUploadsPlugin extends GenericPlugin {
         // Perform MIME type validation
         $detectedMimeType = $this->getMimeTypeFromFile($filePath);
         if ($detectedMimeType === false) {
-            error_log("AllowedUploads: Could not detect MIME type for file " . $fileName);
+            error_log("AllowedUploads: Could not determine MIME type of file " . $fileName);
             return ['valid' => true, 'error' => null];
         }
 
         $expectedMimeTypes = $this->getExpectedMimeTypes($extension);
         if (!empty($expectedMimeTypes) && !in_array($detectedMimeType, $expectedMimeTypes)) {
-            return [
+            error_log("AllowedUploads: SECURITY - MIME type mismatch for user {$userId} in context {$contextId}: {$fileName} " .
+                	  "(detected: {$detectedMimeType}, expected: " . implode(', ', $expectedMimeTypes) . ")");
+			return [
                 'valid' => false,
                 'error' => __('plugins.generic.allowedUploads.error.mimeType', [
                     'fileName' => $fileName,
@@ -315,6 +340,7 @@ class AllowedUploadsPlugin extends GenericPlugin {
                 }
             }
         }
+
 		return false;
     }
 

--- a/AllowedUploadsPlugin.inc.php
+++ b/AllowedUploadsPlugin.inc.php
@@ -106,58 +106,244 @@ class AllowedUploadsPlugin extends GenericPlugin {
 	}
 
 	/**
+	 * Get MIME type from file content
+     * @param string $filePath Path to the file
+     * @return string|false MIME type or false if detection fails
+	 */
+    private function getMimeTypeFromFile($filePath) {
+        if (!file_exists($filePath)) {
+            return false;
+        }
+
+        // Use finfo if available
+        if (function_exists('finfo_open')) {
+            $finfo = finfo_open(FILEINFO_MIME_TYPE);
+            if ($finfo) {
+                $mimeType = finfo_file($finfo, $filePath);
+                finfo_close($finfo);
+                return $mimeType;
+            }
+        }
+
+        // Fallback to mime_content_type as failsafe
+        if (function_exists('mime_content_type')) {
+            return mime_content_type($filePath);
+        }
+
+        return false;
+    }
+
+    /**
+     * Get expected MIME types for file extension
+     * @param string $extension File extension
+     * @return array Array of acceptable MIME types
+     */
+    private function getExpectedMimeTypes($extension) {
+        $mimeMap = [
+			// Document formats
+			'doc' => ['application/msword'],
+			'docx' => ['application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
+			'odt' => ['application/vnd.oasis.opendocument.text'],
+			'pdf' => ['application/pdf'],
+			'rtf' => ['application/rtf', 'text/rtf'],
+			'txt' => ['text/plain'],
+
+			// LaTeX and related
+			'bib' => ['text/x-bibtex', 'application/x-bibtex'],
+			'latex' => ['text/x-tex', 'application/x-latex'],
+			'tex' => ['text/x-tex', 'application/x-tex'],
+
+			// Spreadsheets and data
+			'csv' => ['text/csv', 'text/plain'],
+			'ods' => ['application/vnd.oasis.opendocument.spreadsheet'],
+			'tsv' => ['text/tab-separated-values', 'text/plain'],
+			'xls' => ['application/vnd.ms-excel'],
+			'xlsx' => ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+
+			// Data formats
+			'json' => ['application/json'],
+			'xml' => ['application/xml', 'text/xml'],
+			'yaml' => ['text/yaml', 'application/yaml'],
+			'yml' => ['text/yaml', 'application/yaml'],
+
+			// Presentations
+			'odp' => ['application/vnd.oasis.opendocument.presentation'],
+			'ppt' => ['application/vnd.ms-powerpoint'],
+			'pptx' => ['application/vnd.openxmlformats-officedocument.presentationml.presentation'],
+
+			// Images
+			'bmp' => ['image/bmp'],
+			'eps' => ['application/postscript'],
+			'gif' => ['image/gif'],
+			'jpg' => ['image/jpeg'],
+			'jpeg' => ['image/jpeg'],
+			'png' => ['image/png'],
+			'svg' => ['image/svg+xml'],
+			'tif' => ['image/tiff'],
+			'tiff' => ['image/tiff'],
+
+			// Vector graphics
+			'ai' => ['application/postscript'],
+			'ps' => ['application/postscript'],
+
+			// Archives
+			'7z' => ['application/x-7z-compressed'],
+			'gz' => ['application/gzip'],
+			'tar' => ['application/x-tar'],
+			'tar.bz2' => ['application/x-bzip2'],
+			'tar.gz' => ['application/gzip'],
+			'tar.xz' => ['application/x-xz'],
+			'zip' => ['application/zip'],
+
+			// Code and markup
+			'htm' => ['text/html'],
+			'html' => ['text/html'],
+			'ipynb' => ['application/json'],
+			'md' => ['text/markdown', 'text/plain'],
+			'py' => ['text/x-python', 'text/plain'],
+			'r' => ['text/plain'],
+
+			// Statistical formats
+			'sav' => ['application/x-spss-sav'],
+			'dta' => ['application/x-stata-dta'],
+			'sas7bdat' => ['application/x-sas-data'],
+
+			// Audio/Video
+			'avi' => ['video/x-msvideo'],
+			'mp3' => ['audio/mpeg'],
+			'mp4' => ['video/mp4'],
+			'wav' => ['audio/wav'],
+        ];
+
+        return $mimeMap[strtolower($extension)] ?? [];
+    }
+
+    /**
+     * Validate file extension and optionally MIME type
+     * @param string $fileName Original filename
+     * @param string|null $filePath Path to uploaded file
+     * @param string $allowedExtensions Semicolon-separated list of allowed extensions
+     * @param int $contextId Context ID
+     * @return array Array with 'valid' boolean and 'error' message
+     */
+    private function validateFileType($fileName, $filePath, $allowedExtensions, $contextId) {
+        $parts = explode('.', $fileName);
+        $allowedExtensionsArray = array_filter(array_map('trim', explode(';', $allowedExtensions)), 'strlen');
+
+        // Check for multiple extensions
+        if (count($parts) > 2) {
+            // Check if a double extension is explicitly allowed
+            $doubleExtension = strtolower($parts[count($parts)-2] . '.' . $parts[count($parts)-1]);
+
+            if (in_array($doubleExtension, $allowedExtensionsArray)) {
+                $extension = $doubleExtension; // Use the double extension for MIME type checking
+            } else {
+                return [
+                    'valid' => false,
+                    'error' => __('plugins.generic.allowedUploads.error.multiExtension', ['fileName' => $fileName])
+                ];
+            }
+        } else {
+            $extension = strtolower(end($parts));
+        }
+
+        // Check extension against allowlist
+        if (!in_array($extension, $allowedExtensionsArray)) {
+            return [
+                'valid' => false,
+                'error' => __('plugins.generic.allowedUploads.error', ['allowedExtensions' => $allowedExtensions])
+            ];
+        }
+
+        // Check if MIME type validation is enabled and we have a file to check
+        $validateMimeType = $this->getSetting($contextId, 'validateMimeType');
+        if (!$validateMimeType || !$filePath || !file_exists($filePath)) {
+            return ['valid' => true, 'error' => null];
+        }
+
+        // Perform MIME type validation
+        $detectedMimeType = $this->getMimeTypeFromFile($filePath);
+        if ($detectedMimeType === false) {
+            error_log("AllowedUploads: Could not detect MIME type for file " . $fileName);
+            return ['valid' => true, 'error' => null];
+        }
+
+        $expectedMimeTypes = $this->getExpectedMimeTypes($extension);
+        if (!empty($expectedMimeTypes) && !in_array($detectedMimeType, $expectedMimeTypes)) {
+            return [
+                'valid' => false,
+                'error' => __('plugins.generic.allowedUploads.error.mimeType', [
+                    'fileName' => $fileName,
+                    'detectedType' => $detectedMimeType,
+                    'allowedExtensions' => $allowedExtensions
+                ])
+            ];
+        }
+
+        return ['valid' => true, 'error' => null];
+    }
+
+	/**
 	 * Check the uploaded file in wizard
 	 */
-	function checkUploadWizard($hookName, $params) {
-		$props = $params[2];
-		$locale = $params[4];
+    function checkUploadWizard($hookName, $params) {
+        $props = $params[2];
+        $locale = $params[4];
 
-		if ($fileName = $props['name'][$locale]){
-			$errors =& $params[0];
-			$request = Application::get()->getRequest();
-			$context = $request->getContext();
-			$fileName = $props['name'][$locale];
-			$tmp = explode('.',$fileName);
-			$extension = strtolower(end($tmp));
+        if ($fileName = $props['name'][$locale]){
+            $errors =& $params[0];
+            $request = Application::get()->getRequest();
+            $context = $request->getContext();
+            $contextId = $context->getId();
+            
+            $allowedExtensions = $this->getSetting($contextId, 'allowedExtensions');
 
-			$allowedExtensions = $this->getSetting($context->getId(), 'allowedExtensions');
-
-			if ($allowedExtensions){
-				$allowedExtensionsArray = array_filter(array_map('trim', explode(';', $allowedExtensions )), 'strlen');
-				if (!in_array($extension, $allowedExtensionsArray)){
-					$errors[] = __('plugins.generic.allowedUploads.error', array('allowedExtensions' => $allowedExtensions));
-				}
-			}
-
-
-		}
-	}
+            if ($allowedExtensions){
+                // Try to get the file path if available
+                $filePath = null;
+                if (isset($props['uploadedFile']) && $props['uploadedFile']) {
+                    $filePath = $props['uploadedFile']->getFilePath();
+                }
+                
+                $validation = $this->validateFileType($fileName, $filePath, $allowedExtensions, $contextId);
+                if (!$validation['valid']) {
+                    $errors[] = $validation['error'];
+                }
+            }
+        }
+    }
 
 	/**
 	 * Check the uploaded file
 	 */
-	function checkUpload($hookName, $params) {
-		$form = $params[0];
-		$request = Application::get()->getRequest();
-		$context = $request->getContext();
-		$userVars = $request->getUserVars();
-		$fileName = $userVars['name'];
-		$tmp = explode('.',$fileName);
-		$extension = strtolower(end($tmp));
+    function checkUpload($hookName, $params) {
+        $form = $params[0];
+        $request = Application::get()->getRequest();
+        $context = $request->getContext();
+        $contextId = $context->getId();
+        $userVars = $request->getUserVars();
+        $fileName = $userVars['name'];
 
-		$allowedExtensions = $this->getSetting($context->getId(), 'allowedExtensions');
+        $allowedExtensions = $this->getSetting($contextId, 'allowedExtensions');
 
-		if ($allowedExtensions){
+        if ($allowedExtensions){
+            // Try to get the uploaded file path
+            $filePath = null;
+            $uploadedFiles = $request->getUploadedFiles();
+            if (!empty($uploadedFiles)) {
+                $uploadedFile = reset($uploadedFiles); // Get first uploaded file
+                if ($uploadedFile && is_array($uploadedFile)) {
+                    $filePath = $uploadedFile['tmp_name'] ?? null;
+                }
+            }
 
-			$allowedExtensionsArray = array_filter(array_map('trim', explode(';', $allowedExtensions )), 'strlen');
-
-			if (!in_array($extension, $allowedExtensionsArray)){
-				$form->addError('allowedFileType', __('plugins.generic.allowedUploads.error', ['allowedExtensions' => $allowedExtensions]));
-			}
-
-		}
-		return false;
-	}
+            $validation = $this->validateFileType($fileName, $filePath, $allowedExtensions, $contextId);
+            if (!$validation['valid']) {
+                $form->addError('allowedFileType', $validation['error']);
+            }
+        }
+        return false;
+    }
 
 
 }

--- a/AllowedUploadsPlugin.inc.php
+++ b/AllowedUploadsPlugin.inc.php
@@ -110,50 +110,50 @@ class AllowedUploadsPlugin extends GenericPlugin {
 
 	/**
 	 * Get MIME type from file content
-     * @param string $filePath Path to the file
-     * @return string|false MIME type or false if detection fails
+	 * @param string $filePath Path to the file
+	 * @return string|false MIME type or false if detection fails
 	 */
-    private function getMimeTypeFromFile($filePath) {
-        if (!file_exists($filePath)) {
+	private function getMimeTypeFromFile($filePath) {
+		if (!file_exists($filePath)) {
 			error_log("AllowedUploads: File not found for MIME detection: " . $filePath);
-            return false;
-        }
+			return false;
+		}
 
-        // Use finfo if available
-        if (function_exists('finfo_open')) {
-            $finfo = finfo_open(FILEINFO_MIME_TYPE);
-            if ($finfo) {
-                $mimeType = finfo_file($finfo, $filePath);
-                finfo_close($finfo);
+		// Use finfo if available
+		if (function_exists('finfo_open')) {
+			$finfo = finfo_open(FILEINFO_MIME_TYPE);
+			if ($finfo) {
+				$mimeType = finfo_file($finfo, $filePath);
+				finfo_close($finfo);
 				if ($mimeType !== false) {
-                	return $mimeType;
+					return $mimeType;
 				}
 				error_log("AllowedUploads: finfo_file failed for: " . $filePath);
-        	} else {
+			} else {
 				error_log("AllowedUploads: finfo_open failed");
 			}
 		}
 
-        // Fallback to mime_content_type as failsafe
-        if (function_exists('mime_content_type')) {
+		// Fallback to mime_content_type as failsafe
+		if (function_exists('mime_content_type')) {
 			$mimeType = mime_content_type($filePath);
-            if ($mimeType !== false) {
+			if ($mimeType !== false) {
 				return $mimeType;
 			}
 			error_log("AllowedUploads: mime_content_type failed for: " . $filePath);
-        }
+		}
 
 		error_log("AllowedUploads: All MIME detection methods failed for: " . $filePath);
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Get expected MIME types for file extension
-     * @param string $extension File extension
-     * @return array Array of acceptable MIME types
-     */
-    private function getExpectedMimeTypes($extension) {
-        $mimeMap = [
+	/**
+	 * Get expected MIME types for file extension
+	 * @param string $extension File extension
+	 * @return array Array of acceptable MIME types
+	 */
+	private function getExpectedMimeTypes($extension) {
+		$mimeMap = [
 			// Document formats
 			'doc' => ['application/msword'],
 			'docx' => ['application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
@@ -227,19 +227,19 @@ class AllowedUploadsPlugin extends GenericPlugin {
 			'mp3' => ['audio/mpeg'],
 			'mp4' => ['video/mp4'],
 			'wav' => ['audio/wav'],
-        ];
+		];
 
-        return $mimeMap[strtolower($extension)] ?? [];
-    }
+		return $mimeMap[strtolower($extension)] ?? [];
+	}
 
-    /**
-     * Validate file extension and optionally MIME type
-     * @param string $fileName Original filename
-     * @param string|null $filePath Path to uploaded file
-     * @param string $allowedExtensions Semicolon-separated list of allowed extensions
-     * @param int $contextId Context ID
-     * @return array Array with 'valid' boolean and 'error' message
-     */
+	/**
+	 * Validate file extension and optionally MIME type
+	 * @param string $fileName Original filename
+	 * @param string|null $filePath Path to uploaded file
+	 * @param string $allowedExtensions Semicolon-separated list of allowed extensions
+	 * @param int $contextId Context ID
+	 * @return array Array with 'valid' boolean and 'error' message
+	 */
     private function validateFileType($fileName, $filePath, $allowedExtensions, $contextId) {
 		$request = Application::get()->getRequest();
 		$user = $request->getUser();
@@ -265,65 +265,65 @@ class AllowedUploadsPlugin extends GenericPlugin {
 			];
 		}
 
-        // Check for multiple extensions
-        if (count($parts) > 2) {
-            // Check if a double extension is explicitly allowed
-            $doubleExtension = strtolower($parts[count($parts)-2] . '.' . $parts[count($parts)-1]);
+		// Check for multiple extensions
+		if (count($parts) > 2) {
+			// Check if a double extension is explicitly allowed
+			$doubleExtension = strtolower($parts[count($parts)-2] . '.' . $parts[count($parts)-1]);
 
-            if (in_array($doubleExtension, $allowedExtensionsArray)) {
-                $extension = $doubleExtension; // Use the double extension for MIME type checking
-            } else {
-                return [
-                    'valid' => false,
-                    'error' => __('plugins.generic.allowedUploads.error.multiExtension', ['fileName' => $fileName])
-                ];
-            }
-        } else {
-            $extension = strtolower(end($parts));
-        }
+			if (in_array($doubleExtension, $allowedExtensionsArray)) {
+				$extension = $doubleExtension; // Use the double extension for MIME type checking
+			} else {
+				return [
+					'valid' => false,
+					'error' => __('plugins.generic.allowedUploads.error.multiExtension', ['fileName' => $fileName])
+				];
+			}
+		} else {
+			$extension = strtolower(end($parts));
+		}
 
-        // Check extension against allowlist
-        if (!in_array($extension, $allowedExtensionsArray)) {
-            return [
-                'valid' => false,
-                'error' => __('plugins.generic.allowedUploads.error', ['allowedExtensions' => $allowedExtensions])
-            ];
-        }
+		// Check extension against allowlist
+		if (!in_array($extension, $allowedExtensionsArray)) {
+			return [
+				'valid' => false,
+				'error' => __('plugins.generic.allowedUploads.error', ['allowedExtensions' => $allowedExtensions])
+			];
+		}
 
-        // Check if MIME type validation is enabled and we have a file to check
-        $validateMimeType = $this->getSetting($contextId, 'validateMimeType');
-        if (!$validateMimeType || !$filePath || !file_exists($filePath)) {
-            return ['valid' => true, 'error' => null];
-        }
+		// Check if MIME type validation is enabled and we have a file to check
+		$validateMimeType = $this->getSetting($contextId, 'validateMimeType');
+		if (!$validateMimeType || !$filePath || !file_exists($filePath)) {
+			return ['valid' => true, 'error' => null];
+		}
 
-        // Perform MIME type validation
-        $detectedMimeType = $this->getMimeTypeFromFile($filePath);
-        if ($detectedMimeType === false) {
-            error_log("AllowedUploads: Could not determine MIME type of file " . $fileName);
-            return ['valid' => true, 'error' => null];
-        }
+		// Perform MIME type validation
+		$detectedMimeType = $this->getMimeTypeFromFile($filePath);
+		if ($detectedMimeType === false) {
+			error_log("AllowedUploads: Could not determine MIME type of file " . $fileName);
+			return ['valid' => true, 'error' => null];
+		}
 
 		// Allow empty MIME types to pass (handled separately above)
 		if ($detectedMimeType === 'application/x-empty' || $detectedMimeType === 'inode/x-empty') {
 			return ['valid' => true, 'error' => null];
 		}
 
-        $expectedMimeTypes = $this->getExpectedMimeTypes($extension);
-        if (!empty($expectedMimeTypes) && !in_array($detectedMimeType, $expectedMimeTypes)) {
-            error_log("AllowedUploads: SECURITY - MIME type mismatch for user {$userId} in context {$contextId}: {$fileName} " .
-                	  "(detected: {$detectedMimeType}, expected: " . implode(', ', $expectedMimeTypes) . ")");
+		$expectedMimeTypes = $this->getExpectedMimeTypes($extension);
+		if (!empty($expectedMimeTypes) && !in_array($detectedMimeType, $expectedMimeTypes)) {
+			error_log("AllowedUploads: SECURITY - MIME type mismatch for user {$userId} in context {$contextId}: {$fileName} " .
+						"(detected: {$detectedMimeType}, expected: " . implode(', ', $expectedMimeTypes) . ")");
 			return [
-                'valid' => false,
-                'error' => __('plugins.generic.allowedUploads.error.mimeType', [
-                    'fileName' => $fileName,
-                    'detectedType' => $detectedMimeType,
-                    'allowedExtensions' => $allowedExtensions
-                ])
-            ];
-        }
+				'valid' => false,
+				'error' => __('plugins.generic.allowedUploads.error.mimeType', [
+					'fileName' => $fileName,
+					'detectedType' => $detectedMimeType,
+					'allowedExtensions' => $allowedExtensions
+				])
+			];
+		}
 
-        return ['valid' => true, 'error' => null];
-    }
+		return ['valid' => true, 'error' => null];
+	}
 
 	/**
 	 * Check the uploaded file in the submission wizard
@@ -332,34 +332,34 @@ class AllowedUploadsPlugin extends GenericPlugin {
 	 * @param array $params Hook parameters: errors array, submission, props, actions, locale
 	 * @return bool Always returns false to allow other hooks to process
 	 */
-    function checkUploadWizard($hookName, $params) {
-        $props = $params[2];
-        $locale = $params[4];
+	function checkUploadWizard($hookName, $params) {
+		$props = $params[2];
+		$locale = $params[4];
 
-        if ($fileName = $props['name'][$locale]){
-            $errors =& $params[0];
-            $request = Application::get()->getRequest();
-            $context = $request->getContext();
-            $contextId = $context->getId();
+		if ($fileName = $props['name'][$locale]){
+			$errors =& $params[0];
+			$request = Application::get()->getRequest();
+			$context = $request->getContext();
+			$contextId = $context->getId();
 
-            $allowedExtensions = $this->getSetting($contextId, 'allowedExtensions');
+			$allowedExtensions = $this->getSetting($contextId, 'allowedExtensions');
 
-            if ($allowedExtensions){
+			if ($allowedExtensions){
 				// Get the uploaded file path from $_FILES
 				$filePath = null;
 				if (isset($_FILES['file']) && isset($_FILES['file']['tmp_name'])) {
 					$filePath = $_FILES['file']['tmp_name'];
 				}
 
-                $validation = $this->validateFileType($fileName, $filePath, $allowedExtensions, $contextId);
-                if (!$validation['valid']) {
-                    $errors[] = $validation['error'];
-                }
-            }
-        }
+				$validation = $this->validateFileType($fileName, $filePath, $allowedExtensions, $contextId);
+				if (!$validation['valid']) {
+					$errors[] = $validation['error'];
+				}
+			}
+		}
 
 		return false;
-    }
+	}
 
 	/**
 	 * Check the uploaded file in the upload form
@@ -368,33 +368,33 @@ class AllowedUploadsPlugin extends GenericPlugin {
 	 * @param array $params Hook parameters: form object
 	 * @return bool Always returns fale to allow other hooks to process
 	 */
-    function checkUpload($hookName, $params) {
-        $form = $params[0];
-        $request = Application::get()->getRequest();
-        $context = $request->getContext();
-        $contextId = $context->getId();
-        $userVars = $request->getUserVars();
-        $fileName = $userVars['name'] ?? null;
+	function checkUpload($hookName, $params) {
+		$form = $params[0];
+		$request = Application::get()->getRequest();
+		$context = $request->getContext();
+		$contextId = $context->getId();
+		$userVars = $request->getUserVars();
+		$fileName = $userVars['name'] ?? null;
 		if (!$fileName) {
 			return false;
 		}
 
-        $allowedExtensions = $this->getSetting($contextId, 'allowedExtensions');
+		$allowedExtensions = $this->getSetting($contextId, 'allowedExtensions');
 
-        if ($allowedExtensions){
+		if ($allowedExtensions){
 			// Get the uploaded file path from $_FILES
 			$filePath = null;
 			if (isset($_FILES['file']) && isset($_FILES['file']['tmp_name'])) {
 				$filePath = $_FILES['file']['tmp_name'];
 			}
 
-            $validation = $this->validateFileType($fileName, $filePath, $allowedExtensions, $contextId);
-            if (!$validation['valid']) {
-                $form->addError('allowedFileType', $validation['error']);
-            }
-        }
-        return false;
-    }
+			$validation = $this->validateFileType($fileName, $filePath, $allowedExtensions, $contextId);
+			if (!$validation['valid']) {
+				$form->addError('allowedFileType', $validation['error']);
+			}
+		}
+		return false;
+	}
 
 }
 ?>

--- a/AllowedUploadsSettingsForm.inc.php
+++ b/AllowedUploadsSettingsForm.inc.php
@@ -46,6 +46,7 @@ class AllowedUploadsSettingsForm extends Form {
 		$this->_data = array(
 			'allowedExtensions' => $this->_plugin->getSetting($this->_contextId, 'allowedExtensions'),
 			'validateMimeType' => $this->_plugin->getSetting($this->_contextId, 'validateMimeType'),
+			'allowEmptyFiles' => $this->_plugin->getSetting($this->_contextId, 'allowEmptyFiles')
 		);
 	}
 
@@ -53,7 +54,7 @@ class AllowedUploadsSettingsForm extends Form {
 	 * Assign form data to user-submitted data.
 	 */
 	function readInputData() {
-		$this->readUserVars(array('allowedExtensions', 'validateMimeType'));
+		$this->readUserVars(array('allowedExtensions', 'validateMimeType', 'allowEmptyFiles'));
 	}
 
 	/**
@@ -76,11 +77,15 @@ class AllowedUploadsSettingsForm extends Form {
 		if ($validateMimeType && !$this->testMimeDetection()) {
 			// MIME detection isn't working - add an error
 			$this->addError('validateMimeType', __('plugins.generic.allowedUploads.settings.mimeValidation.unavailable'));
+
+			// Also force the validateMimeType setting back to false so the form shows correctly
+			$this->setData('validateMimeType', false);
 			return false;
     	}
 
 		$this->_plugin->updateSetting($this->_contextId, 'allowedExtensions', $this->getData('allowedExtensions'), 'string');
 		$this->_plugin->updateSetting($this->_contextId, 'validateMimeType', $this->getData('validateMimeType'), 'bool');
+		$this->_plugin->updateSetting($this->_contextId, 'allowEmptyFiles', $this->getData('allowEmptyFiles'), 'bool');
 		return parent::execute(...$functionArgs);
 	}
 
@@ -89,7 +94,7 @@ class AllowedUploadsSettingsForm extends Form {
 	 * @return bool True if MIME detection works
 	 */
 	private function testMimeDetection() {
-		// Test with this PHP file - we know it exists and is readable
+		// Test with this file
 		$testFile = __FILE__;
 
 		// Test finfo_open (primary method)

--- a/AllowedUploadsSettingsForm.inc.php
+++ b/AllowedUploadsSettingsForm.inc.php
@@ -70,9 +70,49 @@ class AllowedUploadsSettingsForm extends Form {
 	 * Save settings.
 	 */
 	function execute(...$functionArgs) {
+		// Check if MIME validation is being enabled
+		$validateMimeType = $this->getData('validateMimeType');
+		
+		if ($validateMimeType && !$this->testMimeDetection()) {
+			// MIME detection isn't working - add an error
+			$this->addError('validateMimeType', __('plugins.generic.allowedUploads.settings.mimeValidation.unavailable'));
+			return false;
+    	}
+
 		$this->_plugin->updateSetting($this->_contextId, 'allowedExtensions', $this->getData('allowedExtensions'), 'string');
 		$this->_plugin->updateSetting($this->_contextId, 'validateMimeType', $this->getData('validateMimeType'), 'bool');
-		parent::execute(...$functionArgs);
+		return parent::execute(...$functionArgs);
+	}
+
+	/**
+	 * Test if MIME type detection is working
+	 * @return bool True if MIME detection works
+	 */
+	private function testMimeDetection() {
+		// Test with this PHP file - we know it exists and is readable
+		$testFile = __FILE__;
+
+		// Test finfo_open (primary method)
+		if (function_exists('finfo_open')) {
+			$finfo = @finfo_open(FILEINFO_MIME_TYPE);
+			if ($finfo !== false) {
+				$mime = @finfo_file($finfo, $testFile);
+				@finfo_close($finfo);
+				if ($mime !== false) {
+					return true;
+				}
+			}
+		}
+
+		// Test fallback method if primary failed
+		if (function_exists('mime_content_type')) {
+			$mime = @mime_content_type($testFile);
+			if ($mime !== false) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 }

--- a/AllowedUploadsSettingsForm.inc.php
+++ b/AllowedUploadsSettingsForm.inc.php
@@ -45,6 +45,7 @@ class AllowedUploadsSettingsForm extends Form {
 	function initData() {
 		$this->_data = array(
 			'allowedExtensions' => $this->_plugin->getSetting($this->_contextId, 'allowedExtensions'),
+			'validateMimeType' => $this->_plugin->getSetting($this->_contextId, 'validateMimeType'),
 		);
 	}
 
@@ -52,7 +53,7 @@ class AllowedUploadsSettingsForm extends Form {
 	 * Assign form data to user-submitted data.
 	 */
 	function readInputData() {
-		$this->readUserVars(array('allowedExtensions'));
+		$this->readUserVars(array('allowedExtensions', 'validateMimeType'));
 	}
 
 	/**
@@ -70,6 +71,7 @@ class AllowedUploadsSettingsForm extends Form {
 	 */
 	function execute(...$functionArgs) {
 		$this->_plugin->updateSetting($this->_contextId, 'allowedExtensions', $this->getData('allowedExtensions'), 'string');
+		$this->_plugin->updateSetting($this->_contextId, 'validateMimeType', $this->getData('validateMimeType'), 'bool');
 		parent::execute(...$functionArgs);
 	}
 

--- a/AllowedUploadsSettingsForm.inc.php
+++ b/AllowedUploadsSettingsForm.inc.php
@@ -34,8 +34,8 @@ class AllowedUploadsSettingsForm extends Form {
 
 		parent::__construct($plugin->getTemplateResource('settingsForm.tpl'));
 
-        $this->addCheck(new \PKP\form\validation\FormValidatorPost($this));
-        $this->addCheck(new \PKP\form\validation\FormValidatorCSRF($this));
+		$this->addCheck(new \PKP\form\validation\FormValidatorPost($this));
+		$this->addCheck(new \PKP\form\validation\FormValidatorCSRF($this));
 
 	}
 
@@ -81,7 +81,7 @@ class AllowedUploadsSettingsForm extends Form {
 			// Also force the validateMimeType setting back to false so the form shows correctly
 			$this->setData('validateMimeType', false);
 			return false;
-    	}
+		}
 
 		$this->_plugin->updateSetting($this->_contextId, 'allowedExtensions', $this->getData('allowedExtensions'), 'string');
 		$this->_plugin->updateSetting($this->_contextId, 'validateMimeType', $this->getData('validateMimeType'), 'bool');

--- a/AllowedUploadsSettingsForm.inc.php
+++ b/AllowedUploadsSettingsForm.inc.php
@@ -69,6 +69,7 @@ class AllowedUploadsSettingsForm extends Form {
 
 	/**
 	 * Save settings.
+	 * @return bool True if settings saved successfully, false on validation error
 	 */
 	function execute(...$functionArgs) {
 		// Check if MIME validation is being enabled

--- a/locale/ar/locale.po
+++ b/locale/ar/locale.po
@@ -25,3 +25,30 @@ msgstr "أضف قائمة بامتدادات الملفات المسموح له�
 
 msgid "plugins.generic.allowedUploads.manager.settings.allowedExtensions"
 msgstr "امتدادات الملفات المسموحة"
+
+msgid "plugins.generic.allowedUploads.manager.settings.validateMimeType"
+msgstr "تمكين التحقق من صحة نوع MIME لتحسين الأمان"
+
+msgid "plugins.generic.allowedUploads.manager.settings.validateMimeType.description"
+msgstr "التحقق من وجود ملفات تتنكر في شكل أنواع أخرى، مثل البرامج الضارة المتنكرة في شكل صورة"
+
+msgid "plugins.generic.allowedUploads.error.noExtension"
+msgstr "{$fileName}: لا يسمح بالملفات التي لا تحتوي على امتدادات ملفات"
+
+msgid "plugins.generic.allowedUploads.error.multiExtension"
+msgstr "{$fileName}: لا يسمح بالملفات ذات امتدادات الملفات المتعددة"
+
+msgid "plugins.generic.allowedUploads.error.mimeType"
+msgstr "تم اكتشاف عدم تطابق نوع الملف: '{$fileName}' لديه نوع MIME غير متوقع '{$detectedType}' وقد يشكل خطرا أمنيا!"
+
+msgid "plugins.generic.allowedUploads.settings.mimeValidation.unavailable"
+msgstr "لا يمكن تمكين التحقق من صحة نوع MIME! لا يعمل اكتشاف MIME الخاص بالخادم بشكل صحيح. يرجى التحقق من تكوين PHP وإعداد mime_database_path في تكوين OJS الخاص بك."
+
+msgid "plugins.generic.allowedUploads.error.emptyFile"
+msgstr "الملفات الفارغة غير مسموح بها"
+
+msgid "plugins.generic.allowedUploads.manager.settings.allowEmptyFiles"
+msgstr "السماح بالملفات الفارغة"
+
+msgid "plugins.generic.allowedUploads.manager.settings.allowEmptyFiles.description"
+msgstr "ضع علامة في هذا المربع للسماح بتحميل الملفات الفارغة (0 بايت)"

--- a/locale/de/locale.po
+++ b/locale/de/locale.po
@@ -25,3 +25,30 @@ msgstr "Fügen Sie eine durch Strichpunkte getrennte Liste der erlaubten Dateier
 
 msgid "plugins.generic.allowedUploads.manager.settings.allowedExtensions"
 msgstr "Erlaubte Dateierweiterungen"
+
+msgid "plugins.generic.allowedUploads.manager.settings.validateMimeType"
+msgstr "Aktivieren der MIME-Typvalidierung für erhöhte Sicherheit"
+
+msgid "plugins.generic.allowedUploads.manager.settings.validateMimeType.description"
+msgstr "Suchen Sie nach Dateien, die sich als andere Typen ausgeben, z.B. Malware, die als Bild getarnt ist"
+
+msgid "plugins.generic.allowedUploads.error.noExtension"
+msgstr "{$fileName}: Dateien ohne Dateiendung sind nicht zulässig."
+
+msgid "plugins.generic.allowedUploads.error.multiExtension"
+msgstr "{$fileName}: Dateien mit mehreren Dateierweiterungen sind nicht zulässig."
+
+msgid "plugins.generic.allowedUploads.error.mimeType"
+msgstr "Dateityp-Diskrepanz erkannt: '{$fileName}' hat einen unerwarteten MIME-Typ '{$detectedType}' und kann ein Sicherheitsrisiko darstellen!"
+
+msgid "plugins.generic.allowedUploads.settings.mimeValidation.unavailable"
+msgstr "Die MIME-Typ-Validierung kann nicht aktiviert werden! Die MIME-Erkennung des Servers funktioniert nicht ordnungsgemäß. Bitte überprüfen Sie Ihre PHP-Konfiguration und die mime_database_path Einstellung in Ihrer OJS-Konfiguration."
+
+msgid "plugins.generic.allowedUploads.error.emptyFile"
+msgstr "Leere Dateien sind nicht zulässig: {$fileName}"
+
+msgid "plugins.generic.allowedUploads.manager.settings.allowEmptyFiles"
+msgstr "Leere Dateien zulassen"
+
+msgid "plugins.generic.allowedUploads.manager.settings.allowEmptyFiles.description"
+msgstr "Aktivieren Sie dieses Kontrollkästchen, um das Hochladen leerer Dateien (0-Byte) zuzulassen"

--- a/locale/en/locale.po
+++ b/locale/en/locale.po
@@ -25,3 +25,12 @@ msgstr "Add a semicolon separated list of allowed file extensions. For example d
 
 msgid "plugins.generic.allowedUploads.manager.settings.allowedExtensions"
 msgstr "Allowed file extensions"
+
+msgid "plugins.generic.allowedUploads.manager.settings.validateMimeType"
+msgstr "Enable MIME type validation for enhanced security"
+
+msgid "plugins.generic.allowedUploads.error.multiExtension"
+msgstr "Files with multiple extensions are not permitted unless specified in the list of allowed extensions: {$fileName}."
+
+msgid "plugins.generic.allowedUploads.error.mimeType"
+msgstr "File type mismatch detected: {$fileName} is of unexpected MIME type {$detectedType} and may pose a security concern."

--- a/locale/en/locale.po
+++ b/locale/en/locale.po
@@ -33,4 +33,7 @@ msgid "plugins.generic.allowedUploads.error.multiExtension"
 msgstr "Files with multiple extensions are not permitted unless specified in the list of allowed extensions: {$fileName}."
 
 msgid "plugins.generic.allowedUploads.error.mimeType"
-msgstr "File type mismatch detected: {$fileName} is of unexpected MIME type {$detectedType} and may pose a security concern."
+msgstr "File type mismatch detected: '{$fileName}' is of unexpected MIME type '{$detectedType}' and may pose a security risk."
+
+msgid "plugins.generic.allowedUploads.settings.mimeValidation.unavailable"
+msgstr "MIME type validation cannot be enabled. This server's MIME detection is not functioning correctly. Please check your PHP configuration and the mime_database_path setting in config.inc.php."

--- a/locale/en/locale.po
+++ b/locale/en/locale.po
@@ -29,14 +29,26 @@ msgstr "Allowed file extensions"
 msgid "plugins.generic.allowedUploads.manager.settings.validateMimeType"
 msgstr "Enable MIME type validation for enhanced security"
 
+msgid "plugins.generic.allowedUploads.manager.settings.validateMimeType.description"
+msgstr "Check for files masquerading as other types, e.g. malware disguised as an image"
+
 msgid "plugins.generic.allowedUploads.error.noExtension"
-msgstr "{$fileName}: Files without extensions are not permitted."
+msgstr "{$fileName}: Files without file extensions are not permitted."
 
 msgid "plugins.generic.allowedUploads.error.multiExtension"
-msgstr "{$fileName}: Files with multiple extensions are not permitted."
+msgstr "{$fileName}: Files with multiple file extensions are not permitted."
 
 msgid "plugins.generic.allowedUploads.error.mimeType"
-msgstr "File type mismatch detected: '{$fileName}' is of unexpected MIME type '{$detectedType}' and may pose a security risk."
+msgstr "File type mismatch detected: '{$fileName}' has unexpected MIME type '{$detectedType}' and may pose a security risk!"
 
 msgid "plugins.generic.allowedUploads.settings.mimeValidation.unavailable"
-msgstr "MIME type validation cannot be enabled. This server's MIME detection is not functioning correctly. Please check your PHP configuration and the mime_database_path setting in config.inc.php."
+msgstr "MIME type validation cannot be enabled! The server's MIME detection is not functioning correctly. Please check your PHP configuration and the mime_database_path setting in your OJS configuration."
+
+msgid "plugins.generic.allowedUploads.error.emptyFile"
+msgstr "Empty files are not permitted: {$fileName}"
+
+msgid "plugins.generic.allowedUploads.manager.settings.allowEmptyFiles"
+msgstr "Allow empty files"
+
+msgid "plugins.generic.allowedUploads.manager.settings.allowEmptyFiles.description"
+msgstr "Check this box to allow empty (0-byte) files to be uploaded"

--- a/locale/en/locale.po
+++ b/locale/en/locale.po
@@ -29,8 +29,11 @@ msgstr "Allowed file extensions"
 msgid "plugins.generic.allowedUploads.manager.settings.validateMimeType"
 msgstr "Enable MIME type validation for enhanced security"
 
+msgid "plugins.generic.allowedUploads.error.noExtension"
+msgstr "{$fileName}: Files without extensions are not permitted."
+
 msgid "plugins.generic.allowedUploads.error.multiExtension"
-msgstr "Files with multiple extensions are not permitted unless specified in the list of allowed extensions: {$fileName}."
+msgstr "{$fileName}: Files with multiple extensions are not permitted."
 
 msgid "plugins.generic.allowedUploads.error.mimeType"
 msgstr "File type mismatch detected: '{$fileName}' is of unexpected MIME type '{$detectedType}' and may pose a security risk."

--- a/locale/es/locale.po
+++ b/locale/es/locale.po
@@ -25,3 +25,30 @@ msgstr "Agregue una lista de las extensiones permitidas separadas por punto y co
 
 msgid "plugins.generic.allowedUploads.manager.settings.allowedExtensions"
 msgstr "Extensiones de archivo permitidas"
+
+msgid "plugins.generic.allowedUploads.manager.settings.validateMimeType"
+msgstr "Habilite la validación de tipo MIME para mejorar la seguridad"
+
+msgid "plugins.generic.allowedUploads.manager.settings.validateMimeType.description"
+msgstr "Comprueba si hay archivos disfrazados de otros tipos, como malware disfrazado de imagen"
+
+msgid "plugins.generic.allowedUploads.error.noExtension"
+msgstr "{$fileName}: No se permiten archivos sin extensiones de archivo."
+
+msgid "plugins.generic.allowedUploads.error.multiExtension"
+msgstr "{$fileName}: No se permiten archivos con varias extensiones de archivo."
+
+msgid "plugins.generic.allowedUploads.error.mimeType"
+msgstr "Se detectó una falta de coincidencia en el tipo de archivo: '{$fileName}' tiene un tipo MIME inesperado '{$detectedType}' y puede suponer un riesgo para la seguridad."
+
+msgid "plugins.generic.allowedUploads.settings.mimeValidation.unavailable"
+msgstr "¡No se puede habilitar la validación de tipo MIME! La detección MIME del servidor no funciona correctamente. Por favor, comprueba tu configuración de PHP y la configuración de mime_database_path en tu configuración de OJS."
+
+msgid "plugins.generic.allowedUploads.error.emptyFile"
+msgstr "No se permiten archivos vacíos: {$fileName}"
+
+msgid "plugins.generic.allowedUploads.manager.settings.allowEmptyFiles"
+msgstr "Permitir archivos vacíos"
+
+msgid "plugins.generic.allowedUploads.manager.settings.allowEmptyFiles.description"
+msgstr "Marque esta casilla para permitir que se carguen archivos vacíos (0 bytes)"

--- a/locale/fi/locale.po
+++ b/locale/fi/locale.po
@@ -25,3 +25,30 @@ msgstr "Lisää puolipisteellä erotettu lista sallituista tiedostomuodoista. Es
 
 msgid "plugins.generic.allowedUploads.manager.settings.allowedExtensions"
 msgstr "Sallitut tiedostomuodot"
+
+msgid "plugins.generic.allowedUploads.manager.settings.validateMimeType"
+msgstr "Ota MIME-tyypin vahvistus käyttöön turvallisuuden parantamiseksi"
+
+msgid "plugins.generic.allowedUploads.manager.settings.validateMimeType.description"
+msgstr "Tarkista, onko tiedostoja, jotka naamioituvat muuntyyppisiksi tiedostoiksi, kuten kuvaksi naamioituja haittaohjelmia"
+
+msgid "plugins.generic.allowedUploads.error.noExtension"
+msgstr "{$fileName}: Tiedostot, joissa ei ole tiedostotunnisteita, eivät ole sallittuja."
+
+msgid "plugins.generic.allowedUploads.error.multiExtension"
+msgstr "{$fileName}: Tiedostot, joilla on useita tiedostotunnisteita, eivät ole sallittuja."
+
+msgid "plugins.generic.allowedUploads.error.mimeType"
+msgstr "Tiedostotyypin ristiriita havaittu: {$fileName}' on odottamaton MIME-tyyppi {$detectedType} ja se voi aiheuttaa tietoturvariskin!"
+
+msgid "plugins.generic.allowedUploads.settings.mimeValidation.unavailable"
+msgstr "MIME-tyypin vahvistusta ei voi ottaa käyttöön! Palvelimen MIME-tunnistus ei toimi oikein. Tarkista PHP-kokoonpanosi ja mime_database_path-asetus OJS-määrityksistäsi."
+
+msgid "plugins.generic.allowedUploads.error.emptyFile"
+msgstr "Tyhjät tiedostot eivät ole sallittuja: {$fileName}"
+
+msgid "plugins.generic.allowedUploads.manager.settings.allowEmptyFiles"
+msgstr "Salli tyhjät tiedostot"
+
+msgid "plugins.generic.allowedUploads.manager.settings.allowEmptyFiles.description"
+msgstr "Valitse tämä ruutu, jos haluat sallia tyhjien (0-tavuisten) tiedostojen lataamisen"

--- a/templates/settingsForm.tpl
+++ b/templates/settingsForm.tpl
@@ -22,6 +22,14 @@
 	<div id="description">{translate key="plugins.generic.allowedUploads.manager.settings.description"}</div>
 
 	{fbvFormArea id="allowedUploadsSettingsFormArea"}
+		{if $errors}
+			<div class="pkp_form_error">
+				{foreach from=$errors item=error}
+					<p>{$error}</p>
+				{/foreach}
+			</div>
+		{/if}
+
 		{fbvFormSection}
 			{fbvElement type="text" id="allowedExtensions" name="allowedExtensions" value=$allowedExtensions label="plugins.generic.allowedUploads.manager.settings.allowedExtensions"}
 		{/fbvFormSection}
@@ -33,13 +41,6 @@
 			{fbvElement type="checkbox" id="allowEmptyFiles" name="allowEmptyFiles" checked=$allowEmptyFiles label="plugins.generic.allowedUploads.manager.settings.allowEmptyFiles"}
 			<div class="sub_label">{translate key="plugins.generic.allowedUploads.manager.settings.allowEmptyFiles.description"}</div>
 		{/fbvFormSection}
-		{if $errors}
-			<div class="pkp_form_error">
-					{foreach from=$errors item=error}
-							<p>{$error}</p>
-					{/foreach}
-			</div>
-	{/if}
 	{/fbvFormArea}
 
 	{fbvFormButtons}

--- a/templates/settingsForm.tpl
+++ b/templates/settingsForm.tpl
@@ -22,8 +22,12 @@
 	<div id="description">{translate key="plugins.generic.allowedUploads.manager.settings.description"}</div>
 
 	{fbvFormArea id="allowedUploadsSettingsFormArea"}
-		{fbvElement type="text" id="allowedExtensions" name="allowedExtensions" value=$allowedExtensions label="plugins.generic.allowedUploads.manager.settings.allowedExtensions"}
-		{fbvElement type="checkbox" id="validateMimeType" name="validateMimeType" checked=$validateMimeType label="plugins.generic.allowedUploads.manager.settings.validateMimeType"}
+		{fbvFormSection}
+			{fbvElement type="text" id="allowedExtensions" name="allowedExtensions" value=$allowedExtensions label="plugins.generic.allowedUploads.manager.settings.allowedExtensions"}
+		{/fbvFormSection}
+		{fbvFormSection list=true}
+			{fbvElement type="checkbox" id="validateMimeType" name="validateMimeType" checked=$validateMimeType label="plugins.generic.allowedUploads.manager.settings.validateMimeType"}
+		{/fbvFormSection}
 	{/fbvFormArea}
 
 	{fbvFormButtons}

--- a/templates/settingsForm.tpl
+++ b/templates/settingsForm.tpl
@@ -27,7 +27,19 @@
 		{/fbvFormSection}
 		{fbvFormSection list=true}
 			{fbvElement type="checkbox" id="validateMimeType" name="validateMimeType" checked=$validateMimeType label="plugins.generic.allowedUploads.manager.settings.validateMimeType"}
+			<div class="sub_label">{translate key="plugins.generic.allowedUploads.manager.settings.validateMimeType.description"}</div>
 		{/fbvFormSection}
+		{fbvFormSection list=true}
+			{fbvElement type="checkbox" id="allowEmptyFiles" name="allowEmptyFiles" checked=$allowEmptyFiles label="plugins.generic.allowedUploads.manager.settings.allowEmptyFiles"}
+			<div class="sub_label">{translate key="plugins.generic.allowedUploads.manager.settings.allowEmptyFiles.description"}</div>
+		{/fbvFormSection}
+		{if $errors}
+			<div class="pkp_form_error">
+					{foreach from=$errors item=error}
+							<p>{$error}</p>
+					{/foreach}
+			</div>
+    {/if}
 	{/fbvFormArea}
 
 	{fbvFormButtons}

--- a/templates/settingsForm.tpl
+++ b/templates/settingsForm.tpl
@@ -23,6 +23,7 @@
 
 	{fbvFormArea id="allowedUploadsSettingsFormArea"}
 		{fbvElement type="text" id="allowedExtensions" name="allowedExtensions" value=$allowedExtensions label="plugins.generic.allowedUploads.manager.settings.allowedExtensions"}
+		{fbvElement type="checkbox" id="validateMimeType" name="validateMimeType" checked=$validateMimeType label="plugins.generic.allowedUploads.manager.settings.validateMimeType"}
 	{/fbvFormArea}
 
 	{fbvFormButtons}

--- a/templates/settingsForm.tpl
+++ b/templates/settingsForm.tpl
@@ -39,7 +39,7 @@
 							<p>{$error}</p>
 					{/foreach}
 			</div>
-    {/if}
+	{/if}
 	{/fbvFormArea}
 
 	{fbvFormButtons}


### PR DESCRIPTION
## Summary
This PR represents a substantial addition motivated by issues like #9.  While not foolproof, it adds significant security enhancements that can prevent uploads of deceptive and malicious files.  In addition to enhancing the effectiveness of the existing convenience features, this PR adds functionality to address several specific security concerns:
- **File type spoofing**: Malicious executables disguised as documents
- **Extensionless file attacks**: Executables uploaded without extensions to bypass filters
- **Multi-extension attacks**: Files like `malware.php.txt` bypassing the existing extension check
- **Empty files**: Files that may be empty due to corruption or as part of social engineering attacks

## Backwards Compatability
New optional features introduced in this plugin will not disrupt current installations on upgrade.  Plugin admins will need to opt-in to these added features via the settings panel.

## MIME Type Validation
The major addition is verification of the file extension by MIME type.  If a user has renamed a file in order to make it appear to be an allowed type ("spoofing"), the plugin should detect this and prevent the upload:

<img height="200" alt="image" src="https://github.com/user-attachments/assets/f691ea23-6158-4381-976e-3ab55a02c6dd" />

## Multiple Extension Blocking
Multiple extensions are blocked unless explicitly added to the allowlist.  E.g., `example.php.txt` will be blocked with the allowlist `doc;php;txt` but will be permitted with the allowlist `doc;php;php.txt;txt`.  This is helpful for some common valid multi-extension file types such as `.tar.gz`.

<img height="200" alt="image" src="https://github.com/user-attachments/assets/6d8b0ba5-9510-4fba-b924-83940179e7c1" />

## Extensionless/Hidden File Blocking
Files with no extension or with hidden file naming are a significant security vulnerability in the existing plugin architecture.  This PR adds logic to block them universally.  If administrators have a legitimate need to accept extensionless or hidden files, submitters could be asked to append a specific, novel extension that the administrators have included in the allowlist.

<img height="200" alt="image" src="https://github.com/user-attachments/assets/08ca1d53-8a9f-443b-a45d-4e24bb8d2880" />

## Empty File Blocking
Empty files (i.e. files with 0 bytes) are a potential attack or nuisance vector and can be optionally blocked with an additional setting.

<img height="200" alt="image" src="https://github.com/user-attachments/assets/c409e168-ce84-4848-a8d7-ecdf092fce1e" />

## Incident Logging
Ordinary blocking of file uploads is not logged (e.g. attempted upload of `.doc` when only `.docx` is permitted), as we can generally assume this to stem from honest mistakes by users.  Spoofing of file types, however, is indicative of deliberate deception, so these attempts and corresponding user account IDs are recorded to the OJS logs:
`[Sun Nov 02 01:33:50.574610 2025] [php:notice] [pid 17:tid 17] [client XXX.XX.0.X:XXXXX] AllowedUploads: SECURITY - MIME type mismatch for user 1 in context 1: imagespoofed.txt (detected: image/jpeg, expected: text/plain), referer: http://localhost:8080/index.php/jambalaya/submission?id=1`

## Settings Panel
The two added options appear with checkbox functionality in the settings form.  As above, these settings will default to values that will not change existing installations on update, so MIME typing will be OFF by default and empty file allowance ON.

<img height="300" alt="image" src="https://github.com/user-attachments/assets/772256af-002e-4780-b07c-ebfdd27a993a" />

## MIME Detection Malfunction Failsafe
OJS 3.4+ requires versions of PHP that contain built-in MIME type detection functionality by default.  If for some reason PHP's `finfo` methods fail, the plugin reverts to an older MIME detection methodology.  Only on a very, very broken installation would neither method be available, but in the event that occurs, the MIME option will present an error if the admin attempts to enable the MIME validation option:

<img height="200" alt="image" src="https://github.com/user-attachments/assets/5014191b-c202-4180-b354-ed0cd358e842" />

## Locales
Translations for the existing languages supported by the plugin have been added for the new messages using Google Translate.  They will almost certainly benefit from editing by native speakers, but what is supplied should hopefully provide a reasonable starting point.

## Code
The code attempts to follow the existing architecture as best as possible.  DocBlocks with annotations are supplied for all functions added by this PR.  Some inline comments have been left in place to facilitate code review, but I'd be happy to remove them if desired.  The file-extension-to-MIME-type mapping array attempts to accommodate many different academic journal submission needs, but I am happy to expand it if something has been overlooked.  It doesn't map many of the more "dangerous" file types (e.g. `.exe`, `.php`) as it is assumed that any journal accepting such file types will probably not find much benefit from disallowing uploads on the basis of file extension.

## README
Some basic description text has been added to the settings form, but I have not updated the README to reflect the features added.  If this PR is accepted I will gladly update the main README to document the added features.

Please let me know you have any questions or suggestions.  Cheers.
